### PR TITLE
[Refector] 급여수정시 수정되지않으면 버튼이 유지되도록 수정

### DIFF
--- a/src/API/Firebase/UpdatePayrollCorApp.ts
+++ b/src/API/Firebase/UpdatePayrollCorApp.ts
@@ -1,32 +1,25 @@
-import { collection, doc, setDoc, getDocs } from 'firebase/firestore';
+import { collection, doc, setDoc, getDocs, query, where } from 'firebase/firestore';
 import { db } from './Firebase_Config.ts';
 
 const updateCorrectionState = async (name: string, month: number, state: string, correctionDetails: string) => {
   try {
     const membersSnapshot = await getDocs(collection(db, 'members'));
-
-    const memberPromises = membersSnapshot.docs.map(async (memberDoc) => {
-      const collectionSnapshot = await getDocs(collection(db, `members/${memberDoc.id}/payrollCorApp`));
-
-      const payDataPromises = collectionSnapshot.docs.map(async (payDataDoc) => {
-        const payDataId = payDataDoc.id;
-        const payData = payDataDoc.data();
-
-        if (payData.name === name && payData.month === month && payData.correctionDetails === correctionDetails) {
-          await setDoc(doc(db, `members/${memberDoc.id}/payrollCorApp`, payDataId), {
-            name: payData.name,
-            month: payData.month,
-            correctionState: state,
-            correctionDetails: payData.correctionDetails,
-            reasonForApplication: payData.reasonForApplication,
-          });
-        }
+    const payrollCorAppUpdatePromise = membersSnapshot.docs.map(async (memberDoc) => {
+      const q = query(
+        collection(db, 'members', memberDoc.id, 'payrollCorApp'),
+        where('name', '==', name),
+        where('month', '==', month),
+        where('correctionDetails', '==', correctionDetails),
+      );
+      const querySnapshot = await getDocs(q);
+      return querySnapshot.docs.map(async (docSnapshot) => {
+        setDoc(doc(db, 'members', memberDoc.id, 'payrollCorApp', docSnapshot.id), {
+          ...docSnapshot.data(),
+          correctionState: state,
+        });
       });
-
-      await Promise.all(payDataPromises);
     });
-
-    await Promise.all(memberPromises);
+    await Promise.all(payrollCorAppUpdatePromise);
   } catch (error) {
     console.error('Error updating correction state:', error);
   }

--- a/src/components/PayrollList/PayList.tsx
+++ b/src/components/PayrollList/PayList.tsx
@@ -22,7 +22,7 @@ interface PayListProps {
   openModalName: string | null;
   onSpacificationModal: (name: string | null) => void;
   adminViewed: boolean;
-  errText: string;
+  errText: string | null;
 }
 
 const PayList: React.FC<PayListProps> = ({

--- a/src/components/PayrollList/SalaryList.tsx
+++ b/src/components/PayrollList/SalaryList.tsx
@@ -121,7 +121,7 @@ const stateCheckBtn = css`
 
 const employee = css`
   position: absolute;
-  right: 0;
+  right: 10px;
   margin-top: 2px;
   span {
     font-size: 20px;

--- a/src/components/PayrollList/SpacificationModal.tsx
+++ b/src/components/PayrollList/SpacificationModal.tsx
@@ -7,7 +7,7 @@
 /* eslint-disable no-unused-expressions */
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import React, { useState, useRef } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import Button from '../Button.tsx';
 import { useAuthContext } from '../../Context/AuthContext.tsx';
 import Select from '../Select.tsx';
@@ -27,7 +27,7 @@ interface PayListProps {
   addSalaryCorrectionList: (name: string, reason: string, textareaValue: string | null) => void;
   month: number;
   isNull: boolean;
-  errText: string;
+  errText: string | null;
 }
 
 const SpacificationModal: React.FC<PayListProps> = ({
@@ -49,12 +49,20 @@ const SpacificationModal: React.FC<PayListProps> = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { user } = useAuthContext();
 
-  const handleSelect = (option: string) => {
-    setReason(option);
-  };
+  useEffect(() => {
+    errText !== null ? setReadOnly(false) : setReadOnly(true);
+  }, [errText]);
 
   const handleReadOnly = () => {
-    readOnly ? setReadOnly(false) : setReadOnly(true);
+    if (errText === null && readOnly) {
+      setReadOnly(false);
+    } else if (errText === null && !readOnly) {
+      setReadOnly(true);
+    }
+  };
+
+  const handleSelect = (option: string) => {
+    setReason(option);
   };
 
   const changePay = (pay: number): string => pay.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/src/pages/Payroll/PayrollHistory.tsx
+++ b/src/pages/Payroll/PayrollHistory.tsx
@@ -66,7 +66,7 @@ const PayrollHistory: React.FC = () => {
   const [originalSalaryCorrectionLists, setOriginalSalaryCorrectionLists] = useState<SalaryCorrection[]>([]);
   const [month, setMonth] = useState('2024 07월');
   const [btnId, setBtnId] = useState<string>('');
-  const [errText, setErrText] = useState<string>('');
+  const [errText, setErrText] = useState<string | null>(null);
   const [isNull, setIsNull] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [openModalName, setOpenModalName] = useState<string | null>(null);
@@ -214,7 +214,7 @@ const PayrollHistory: React.FC = () => {
           });
           dispatch(setEmployeeSalary(newEmploySalary));
           additionalPayUpdate(name, month, Number(additionalPayChange), user?.isAdmin);
-          setErrText('');
+          setErrText(null);
         } else {
           setErrText('숫자만 입력 가능합니다.');
         }
@@ -233,7 +233,7 @@ const PayrollHistory: React.FC = () => {
         });
         dispatch(setEmployeeSalary(newFilterEmploySalary));
         additionalPayUpdate(name, month, Number(inputValue), user?.isAdmin);
-        setErrText('');
+        setErrText(null);
       } else {
         setErrText('숫자만 입력 가능합니다.');
       }
@@ -255,7 +255,7 @@ const PayrollHistory: React.FC = () => {
         correctionState: 'standBy',
       });
       setIsNull(false);
-      dispatch(hiddenModal('spacificationModal'));
+      setOpenModalName(null);
       setSalaryCorrectionLists(newSalaryCorrectionLists);
       createPayrollCorApp(name, currentDate, reason, textareaValue);
     } else {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

 급여수정시 수정되지않으면 버튼이 유지되도록 수정
 firebase API 멘토님 코드리뷰 반영하여 수정

## 🔧 변경 사항

- 급여수정시 수정되지않으면 버튼과 input변경창이 유지되도록 수정
- 직원 정정요청내역에서 x표시 css 위치 수정
- 직원 정정요청 후 모달 닫히지않던 것 수정
- firebase API 멘토님 코드리뷰 반영하여 수정
